### PR TITLE
Fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dependencies = [
     "transformers>=4.45.0",
     "numpy",
     "openai",
+    "anthropic",
+    "ipykernel",
+    "peft",
+    "sentencepiece",
 ]
 
 [project.optional-dependencies]

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ setup(
         "transformers>=4.45.0",
         "numpy",
         "openai",
+        "anthropic",
+        "ipykernel",
+        "peft",
+        "sentencepiece",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Added four packages to `pyproject.toml` and `setup.py`:
```
"anthropic",
"ipykernel",
"peft",
"sentencepiece"
```

`peft` and `sentencepiece` are required for properly loading the `qylu4156/strongreject-15k-v1` model

